### PR TITLE
Add fulltext argument to supported endpoints

### DIFF
--- a/podcastindex/podcastindex.py
+++ b/podcastindex/podcastindex.py
@@ -96,7 +96,8 @@ class PodcastIndex:
         """
         # Perform request
         headers = self._create_headers()
-        result = requests.post(url, headers=headers, data=payload, timeout=self.timeout)
+        result = requests.post(url, headers=headers,
+                               data=payload, timeout=self.timeout)
         result.raise_for_status()
 
         # Parse the result as a dict
@@ -339,6 +340,39 @@ class PodcastIndex:
             payload["excludeString"] = excluding
         if before_episode_id:
             payload["before"] = before_episode_id
+
+        # Call Api for result
+        return self._make_request_get_result_helper(url, payload)
+
+    def trendingPodcasts(self, max=10, since=None, lang=None, categories=None, not_categories=None):
+        """
+        Returns the podcasts in the index that are trending.
+
+        Args:
+            max (int): Maximum number of results to return. Default: 10
+            since (int): Return items since the specified time. Can be a unix epoch timestamp or a negative integer
+                that represents a number of seconds prior to right now
+            lang ([string], optional): Specifying a language code will return podcasts only in that language.
+            categories ([string or int], optional): A list of categories used to limit which podcasts will be included
+                in results. Category names and IDs are both supported.
+            not_categories ([string or int], optional): A list of categories used to limit exclude certain podcasts
+                from results. Category names and IDs are both supported.
+        """
+        # Setup request
+        url = self.base_url + "/podcasts/trending"
+
+        # Setup payload
+        payload = {}
+        if max:
+            payload["max"] = max
+        if since:
+            payload["since"] = since
+        if lang:
+            payload["lang"] = ",".join(str(i) for i in lang)
+        if categories:
+            payload["cat"] = ",".join(str(i) for i in categories)
+        if not_categories:
+            payload["notcat"] = ",".join(str(i) for i in not_categories)
 
         # Call Api for result
         return self._make_request_get_result_helper(url, payload)

--- a/podcastindex/podcastindex.py
+++ b/podcastindex/podcastindex.py
@@ -104,13 +104,15 @@ class PodcastIndex:
         result_dict = json.loads(result.text)
         return result_dict
 
-    def search(self, query, clean=False):
+    def search(self, query, clean=False, fulltext=False):
         """
         Returns all of the feeds that match the search terms in the title, author or owner of the feed.
 
         Args:
             query (str): Query string
             clean (bool): Return only non-explicit feeds
+            fulltext (bool): Whether to return the full text value of any text fields. If false, field values
+                will be truncated to 100 words. Default: False
 
         Raises:
             requests.exceptions.HTTPError: When the status code is not OK.
@@ -126,6 +128,8 @@ class PodcastIndex:
         payload = {"q": query}
         if clean:
             payload["clean"] = 1
+        if fulltext:
+            payload["fulltext"] = True
 
         # Call Api for result
         return self._make_request_get_result_helper(url, payload)
@@ -199,7 +203,7 @@ class PodcastIndex:
         # Call Api for result
         return self._make_request_get_result_helper(url, payload)
 
-    def episodesByFeedUrl(self, feedUrl, since=None, max_results=10):
+    def episodesByFeedUrl(self, feedUrl, since=None, max_results=10, fulltext=False):
         """
         Lookup episodes by feedUrl, returned in reverse chronological order.
 
@@ -208,6 +212,8 @@ class PodcastIndex:
             since (integer): Unix timestamp, or a negative integer that represents a number of seconds prior to right
                              now. The search will start from that time and only return feeds updated since then.
             max_results (integer): Maximum number of results to return. Default: 10
+            fulltext (boolean): Whether to return the full text value of any text fields. If false, field values
+                                will be truncated to 100 words. Default: False
 
         Raises:
             requests.exceptions.HTTPError: When the status code is not OK.
@@ -223,11 +229,13 @@ class PodcastIndex:
         payload = {"url": feedUrl, "max": max_results}
         if since:
             payload["since"] = since
+        if fulltext:
+            payload["fulltext"] = True
 
         # Call Api for result
         return self._make_request_get_result_helper(url, payload)
 
-    def episodesByFeedId(self, feedId, since=None, max_results=10):
+    def episodesByFeedId(self, feedId, since=None, max_results=10, fulltext=False):
         """
         Lookup episodes by feedId, returned in reverse chronological order.
 
@@ -236,6 +244,8 @@ class PodcastIndex:
             since (integer): Unix timestamp, or a negative integer that represents a number of seconds prior to right
                              now. The search will start from that time and only return feeds updated since then.
             max_results (integer): Maximum number of results to return. Default: 10
+            fulltext (boolean): Whether to return the full text value of any text fields. If false, field values
+                                will be truncated to 100 words. Default: False
 
         Raises:
             requests.exceptions.HTTPError: When the status code is not OK.
@@ -251,11 +261,13 @@ class PodcastIndex:
         payload = {"id": feedId, "max": max_results}
         if since:
             payload["since"] = since
+        if fulltext:
+            payload["fulltext"] = True
 
         # Call Api for result
         return self._make_request_get_result_helper(url, payload)
 
-    def episodesByItunesId(self, itunesId, since=None, max_results=10):
+    def episodesByItunesId(self, itunesId, since=None, max_results=10, fulltext=False):
         """
         Lookup episodes by itunesId, returned in reverse chronological order.
 
@@ -264,6 +276,8 @@ class PodcastIndex:
             since (integer): Unix timestamp, or a negative integer that represents a number of seconds prior to right
                 now. The search will start from that time and only return feeds updated since then.
             max_results (integer): Maximum number of results to return. Default: 10
+            fulltext (boolean): Whether to return the full text value of any text fields. If false, field values
+                will be truncated to 100 words. Default: False
 
         Raises:
             requests.exceptions.HTTPError: When the status code is not OK.
@@ -279,20 +293,23 @@ class PodcastIndex:
         payload = {
             "id": itunesId,
             "max": max_results,
-            "fulltext": True,
         }
         if since:
             payload["since"] = since
+        if fulltext:
+            payload["fulltext"] = True
 
         # Call Api for result
         return self._make_request_get_result_helper(url, payload)
 
-    def episodeById(self, id):
+    def episodeById(self, id, fulltext=False):
         """
         Lookup episode by id internal to podcast index.
 
         Args:
             id (string or integer): Episode ID.
+            fulltext (boolean): Whether to return the full text value of any text fields. If false, field values
+                will be truncated to 100 words. Default: False
 
         Raises:
             requests.exceptions.HTTPError: When the status code is not OK.
@@ -306,11 +323,13 @@ class PodcastIndex:
 
         # Setup payload
         payload = {"id": id}
+        if fulltext:
+            payload["fulltext"] = True
 
         # Call Api for result
         return self._make_request_get_result_helper(url, payload)
 
-    def recentEpisodes(self, max=None, excluding=None, before_episode_id=None):
+    def recentEpisodes(self, max=None, excluding=None, before_episode_id=None, fulltext=False):
         """
         Returns the most recent [max] number of episodes globally across the whole index, in reverse chronological
         order.
@@ -321,6 +340,8 @@ class PodcastIndex:
                 the result set.
             before_episode_id (int, optional): Get recent episodes before this episode id, allowing you to walk back
                 through the episode history sequentially.
+            fulltext (boolean): Whether to return the full text value of any text fields. If false, field values
+                will be truncated to 100 words. Default: False
 
         Raises:
             requests.exceptions.HTTPError: When the status code is not OK.
@@ -340,6 +361,8 @@ class PodcastIndex:
             payload["excludeString"] = excluding
         if before_episode_id:
             payload["before"] = before_episode_id
+        if fulltext:
+            payload["fulltext"] = True
 
         # Call Api for result
         return self._make_request_get_result_helper(url, payload)

--- a/tests/test_trending_podcasts.py
+++ b/tests/test_trending_podcasts.py
@@ -1,0 +1,66 @@
+import logging
+import time
+
+import podcastindex
+
+logging.basicConfig(level=logging.DEBUG)
+logger = logging.getLogger()
+
+
+def _log_results(context, results):
+    logger.ingo("Podcast results from {}".format(context))
+    for feed in results["feeds"]:
+        logger.info(
+            "Podcast Id: {} \t Title: {} \t Newest item publish time: {} \t Categories: {}".format(
+                feed["id"], feed["title"], feed["newestItemPublishTime"], feed["categories"])
+        )
+
+
+def test_trending_podcasts_max():
+    config = podcastindex.get_config_from_env()
+    index = podcastindex.init(config)
+
+    results = index.trendingPodcasts(max=15)
+    assert len(results["feeds"]
+               ) == 15, "By default we expect to get back 10 results"
+
+
+def test_trending_podcasts_since():
+    config = podcastindex.get_config_from_env()
+    index = podcastindex.init(config)
+
+    results = index.trendingPodcasts(since=-(24 * 3600))
+    for feed in results["feeds"]:
+        last_updated = feed["newestItemPublishTime"]
+        assert time.time() - last_updated < 24 * 3600
+
+
+def test_trending_podcasts_lang():
+    config = podcastindex.get_config_from_env()
+    index = podcastindex.init(config)
+
+    results = index.trendingPodcasts(lang=["es"])
+    for feed in results["feeds"]:
+        assert feed["language"] == "es"
+
+
+def test_trending_podcasts_categories():
+    config = podcastindex.get_config_from_env()
+    index = podcastindex.init(config)
+    categories = ["News", "Comedy"]
+
+    results = index.trendingPodcasts(categories=categories)
+    for feed in results["feeds"]:
+        assert categories[0] in feed["categories"].values(
+        ) or categories[1] in feed["categories"].values()
+
+
+def test_trending_podcasts_not_categories():
+    config = podcastindex.get_config_from_env()
+    index = podcastindex.init(config)
+    categories = ["News", "Comedy"]
+
+    results = index.trendingPodcasts(not_categories=categories)
+    for feed in results["feeds"]:
+        for id in feed["categories"]:
+            assert not feed["categories"][id] in categories


### PR DESCRIPTION
Several endpoints have an optional fulltext parameter to control whether text values should be truncated to 100 words. This simply adds an optional fulltext argument to the functions that call those endpoints which defaults to False (same default behavior as the API).