### PR TITLE
Refactor to support asynchronous calls. Switching to aiohttp instead of requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ index = podcastindex.init(config)
 ### Search
 
 ```python
-result = index.search("This American Life")
-result = index.search("This American Life", clean=True)
+result = await index.search("This American Life")
+result = await index.search("This American Life", clean=True)
 ```
 
 <details>
@@ -93,9 +93,9 @@ result = index.search("This American Life", clean=True)
 ### Podcasts
 
 ```python
-results = index.podcastByFeedId(522613)
-results = index.podcastByFeedUrl("http://feed.thisamericanlife.org/talpodcast")
-results = index.podcastByItunesId(201671138)
+results = await index.podcastByFeedId(522613)
+results = await index.podcastByFeedUrl("http://feed.thisamericanlife.org/talpodcast")
+results = await index.podcastByItunesId(201671138)
 ```
 
 <details>
@@ -142,12 +142,12 @@ results = index.podcastByItunesId(201671138)
 ### Episodes of a podcast
 
 ```python
-results = index.episodesByFeedId(522613)
-results = index.episodesByFeedUrl("http://feed.thisamericanlife.org/talpodcast")
-results = index.episodesByItunesId(201671138)
+results = await index.episodesByFeedId(522613)
+results = await index.episodesByFeedUrl("http://feed.thisamericanlife.org/talpodcast")
+results = await index.episodesByItunesId(201671138)
 
-results = index.episodesByFeedId(522613, since=-525600)  # in the last year
-results = index.episodesByFeedId(522613, since=1577836800)  # Jan 1st 2020
+results = await index.episodesByFeedId(522613, since=-525600)  # in the last year
+results = await index.episodesByFeedId(522613, since=1577836800)  # Jan 1st 2020
 ```
 
 <details>
@@ -195,7 +195,7 @@ results = index.episodesByFeedId(522613, since=1577836800)  # Jan 1st 2020
 ### Episode by ID
 
 ```python
-results = index.episodeById(1270106072)
+results = await index.episodeById(1270106072)
 ```
 
 <details>
@@ -240,7 +240,7 @@ results = index.episodeById(1270106072)
 ### Recent episodes
 
 ```python
-results = index.recentEpisodes(max=5, excluding="trump", before_episode_id=1270106072)
+results = await index.recentEpisodes(max=5, excluding="trump", before_episode_id=1270106072)
 ```
 
 <details>

--- a/podcastindex/podcastindex.py
+++ b/podcastindex/podcastindex.py
@@ -199,7 +199,7 @@ class PodcastIndex:
         # Call Api for result
         return self._make_request_get_result_helper(url, payload)
 
-    def episodesByFeedUrl(self, feedUrl, since=None, max_results=10):
+    def episodesByFeedUrl(self, feedUrl, since=None, max_results=10, fulltext=False):
         """
         Lookup episodes by feedUrl, returned in reverse chronological order.
 
@@ -208,6 +208,7 @@ class PodcastIndex:
             since (integer): Unix timestamp, or a negative integer that represents a number of seconds prior to right
                              now. The search will start from that time and only return feeds updated since then.
             max_results (integer): Maximum number of results to return. Default: 10
+            fulltext (bool): Return full text in the text fields. Default: False
 
         Raises:
             requests.exceptions.HTTPError: When the status code is not OK.
@@ -223,11 +224,15 @@ class PodcastIndex:
         payload = {"url": feedUrl, "max": max_results}
         if since:
             payload["since"] = since
+        if fulltext:
+            payload["fulltext"] = True
 
         # Call Api for result
         return self._make_request_get_result_helper(url, payload)
 
-    def episodesByFeedId(self, feedId, since=None, max_results=10):
+    def episodesByFeedId(
+        self, feedId, since=None, max_results=10, fulltext=False, enclosure=None
+    ):
         """
         Lookup episodes by feedId, returned in reverse chronological order.
 
@@ -236,6 +241,8 @@ class PodcastIndex:
             since (integer): Unix timestamp, or a negative integer that represents a number of seconds prior to right
                              now. The search will start from that time and only return feeds updated since then.
             max_results (integer): Maximum number of results to return. Default: 10
+            fulltext (bool): Return full text in the text fields. Default: False
+            enclosure (string): The URL for the episode enclosure to get the information for.
 
         Raises:
             requests.exceptions.HTTPError: When the status code is not OK.
@@ -251,11 +258,17 @@ class PodcastIndex:
         payload = {"id": feedId, "max": max_results}
         if since:
             payload["since"] = since
+        if fulltext:
+            payload["fulltext"] = True
+        if enclosure:
+            payload["enclosure"] = enclosure
 
         # Call Api for result
         return self._make_request_get_result_helper(url, payload)
 
-    def episodesByItunesId(self, itunesId, since=None, max_results=10):
+    def episodesByItunesId(
+        self, itunesId, since=None, max_results=10, fulltext=False, enclosure=None
+    ):
         """
         Lookup episodes by itunesId, returned in reverse chronological order.
 
@@ -264,6 +277,9 @@ class PodcastIndex:
             since (integer): Unix timestamp, or a negative integer that represents a number of seconds prior to right
                 now. The search will start from that time and only return feeds updated since then.
             max_results (integer): Maximum number of results to return. Default: 10
+            fulltext (bool): Return full text in the text fields. Default: False
+            enclosure (string): The URL for the episode enclosure to get the information for.
+
 
         Raises:
             requests.exceptions.HTTPError: When the status code is not OK.
@@ -283,16 +299,21 @@ class PodcastIndex:
         }
         if since:
             payload["since"] = since
+        if fulltext:
+            payload["fulltext"] = True
+        if enclosure:
+            payload["enclosure"] = enclosure
 
         # Call Api for result
         return self._make_request_get_result_helper(url, payload)
 
-    def episodeById(self, id):
+    def episodeById(self, id, fulltext=False):
         """
         Lookup episode by id internal to podcast index.
 
         Args:
             id (string or integer): Episode ID.
+            fulltext (bool): Return full text in the text fields. Default: False
 
         Raises:
             requests.exceptions.HTTPError: When the status code is not OK.
@@ -306,17 +327,20 @@ class PodcastIndex:
 
         # Setup payload
         payload = {"id": id}
+        if fulltext:
+            payload["fulltext"] = True
 
         # Call Api for result
         return self._make_request_get_result_helper(url, payload)
-    
-    def episodesByPerson(self, query, clean=False):
+
+    def episodesByPerson(self, query, clean=False, fulltext=False):
         """
         Returns all of the episodes where the specified person is mentioned.
 
         Args:
             query (str): Query string
             clean (bool): Return only non-explicit feeds
+            fulltext (bool): Return full text in the text fields. Default: False
 
         Raises:
             requests.exceptions.HTTPError: When the status code is not OK.
@@ -332,11 +356,15 @@ class PodcastIndex:
         payload = {"q": query}
         if clean:
             payload["clean"] = 1
+        if fulltext:
+            payload["fulltext"] = True
 
         # Call Api for result
         return self._make_request_get_result_helper(url, payload)
-    
-    def recentEpisodes(self, max=None, excluding=None, before_episode_id=None):
+
+    def recentEpisodes(
+        self, max=None, excluding=None, before_episode_id=None, fulltext=False
+    ):
         """
         Returns the most recent [max] number of episodes globally across the whole index, in reverse chronological
         order.
@@ -347,6 +375,7 @@ class PodcastIndex:
                 the result set.
             before_episode_id (int, optional): Get recent episodes before this episode id, allowing you to walk back
                 through the episode history sequentially.
+            fulltext (bool): Return full text in the text fields. Default: False
 
         Raises:
             requests.exceptions.HTTPError: When the status code is not OK.
@@ -366,6 +395,8 @@ class PodcastIndex:
             payload["excludeString"] = excluding
         if before_episode_id:
             payload["before"] = before_episode_id
+        if fulltext:
+            payload["fulltext"] = True
 
         # Call Api for result
         return self._make_request_get_result_helper(url, payload)

--- a/podcastindex/podcastindex.py
+++ b/podcastindex/podcastindex.py
@@ -401,7 +401,88 @@ class PodcastIndex:
         # Call Api for result
         return self._make_request_get_result_helper(url, payload)
 
-    def trendingPodcasts(self, max=10, since=None, lang=None, categories=None, not_categories=None):
+    def recentFeeds(
+        self, max=40, since=None, lang=None, categories=None, not_categories=None
+    ):
+        """
+        Returns the most recent [max] feeds, in reverse chronological order.
+
+        Args:
+            max (int, optional): Maximum number of results to return. Default: 40
+            since (int): Return items since the specified time. Can be a unix epoch timestamp or a negative integer
+                that represents a number of seconds prior to right now
+            lang ([string], optional): Specifying a language code will return podcasts only in that language.
+            categories ([string or int], optional): A list of categories used to limit which podcasts will be included
+                in results. Category names and IDs are both supported.
+            not_categories ([string or int], optional): A list of categories used to limit exclude certain podcasts
+                from results. Category names and IDs are both supported.
+
+        Raises:
+            requests.exceptions.HTTPError: When the status code is not OK.
+            requests.exceptions.ReadTimeout: When the request times out.
+
+        Returns:
+            Dict: API response
+        """
+        # Setup request
+        url = self.base_url + "/recent/feeds"
+
+        # Setup payload
+        payload = {}
+        if max:
+            payload["max"] = max
+        if since:
+            payload["since"] = since
+        if lang:
+            payload["lang"] = ",".join(str(i) for i in lang)
+        if categories:
+            payload["cat"] = ",".join(str(i) for i in categories)
+        if not_categories:
+            payload["notcat"] = ",".join(str(i) for i in not_categories)
+
+        # Call Api for result
+        return self._make_request_get_result_helper(url, payload)
+
+    def newFeeds(self, max=40, since=None, feed_id=None, desc=None):
+        """
+        Returns every new feed added to the index over the past 24 hours in reverse chronological order.
+
+        Args:
+            max (int, optional): Maximum number of results to return. Default: 40
+            since (int): Return items since the specified time. Can be a unix epoch timestamp or a negative integer
+                that represents a number of seconds prior to right now
+            feed_id (string or int): The PodcastIndex Feed ID to start from (or go to if desc specified).
+                If since parameter also specified, value of since is ignored.
+            desc (bool): If true, return results in descending order. Only applicable when using feedid parameter.
+                Default: False
+
+        Raises:
+            requests.exceptions.HTTPError: When the status code is not OK.
+            requests.exceptions.ReadTimeout: When the request times out.
+
+        Returns:
+            Dict: API response
+        """
+        # Setup request
+        url = self.base_url + "/recent/feeds"
+
+        # Setup payload
+        payload = {}
+        if max:
+            payload["max"] = max
+        if since:
+            payload["since"] = since
+        if feed_id:
+            payload["feedid"] = feed_id
+        if desc:
+            payload["desc"] = desc
+
+        # Call Api for result
+        return self._make_request_get_result_helper(url, payload)
+
+    def trendingPodcasts(
+        self, max=10, since=None, lang=None, categories=None, not_categories=None
+    ):
         """
         Returns the podcasts in the index that are trending.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 requests
+aiohttp
 
 # For development
 black;python_version>='3.6'

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ wheel
 codecov
 coverage
 pytest
+pytest-asyncio

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="python-podcastindex",
-    version="1.10.0",
+    version="1.11.0",
     description="A python wrapper for the Podcast Index API (podcastindex.org).",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/tests/test_episode_lookup.py
+++ b/tests/test_episode_lookup.py
@@ -1,24 +1,25 @@
 import logging
 
-import podcastindex
+import aiohttp
 import pytest
-import requests
+
+import podcastindex
 
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger()
 
-feedUrl = "http://feed.thisamericanlife.org/talpodcast"
-feedId = 522613
-itunesId = 201671138
+feedUrl = "https://lexfridman.com/feed/podcast/"
+feedId = 745287
+itunesId = 1434243584
 badItunesId = "abcdefg1234"
 
-
-def test_episode_lookup_by_feedid():
+@pytest.mark.asyncio
+async def test_episode_lookup_by_feedid():
     config = podcastindex.get_config_from_env()
     index = podcastindex.init(config)
 
     # Test basic episode retrieval
-    results = index.episodesByFeedId(feedId)
+    results = await index.episodesByFeedId(feedId)
     assert len(results["items"]) > 0, "No episodes found when looking up episodes by feed ID."
     assert (
         results["items"][0]["feedItunesId"] == itunesId
@@ -28,7 +29,7 @@ def test_episode_lookup_by_feedid():
     most_recent_ep_timestamp = results["items"][0]["datePublished"]
     since_timestamp = most_recent_ep_timestamp - 1
 
-    results = index.episodesByFeedId(feedId, since=since_timestamp)
+    results = await index.episodesByFeedId(feedId, since=since_timestamp)
     assert (
         len(results["items"]) > 0
     ), "We should get back at least one episode when looking for episodes since right before the most recent episode."
@@ -39,42 +40,46 @@ def test_episode_lookup_by_feedid():
         ), "Looking for episodes since right before the most recent episode is not correct."
 
 
-def test_episode_lookup_by_feedurl():
+@pytest.mark.asyncio
+async def test_episode_lookup_by_feedurl():
     config = podcastindex.get_config_from_env()
     index = podcastindex.init(config)
 
-    results = index.episodesByFeedUrl(feedUrl)
+    results = await index.episodesByFeedUrl(feedUrl)
     assert len(results["items"]) > 0, "No episodes found when looking up episodes by feed URL."
     assert (
         results["items"][0]["feedItunesId"] == itunesId
     ), "Episodes found do not belong to the feed URL used in the query"
 
 
-def test_episode_lookup_by_itunesid():
+@pytest.mark.asyncio
+async def test_episode_lookup_by_itunesid():
     config = podcastindex.get_config_from_env()
     index = podcastindex.init(config)
 
-    results = index.episodesByItunesId(itunesId)
+    results = await index.episodesByItunesId(itunesId)
     assert len(results["items"]) > 0, "No episodes found when looking up episodes by Itunes ID."
     assert (
         results["items"][0]["feedItunesId"] == itunesId
     ), "Episodes found do not belong to the Itunes ID used in the query"
 
 
-def test_erroneous_episode_lookup_by_itunesid():
+@pytest.mark.asyncio
+async def test_erroneous_episode_lookup_by_itunesid():
     config = podcastindex.get_config_from_env()
     index = podcastindex.init(config)
 
-    with pytest.raises(requests.exceptions.ReadTimeout):
-        index.episodesByItunesId(badItunesId)
+    with pytest.raises(aiohttp.ClientResponseError):
+        await index.episodesByItunesId(badItunesId)
 
 
-def test_episode_lookup_by_id():
+@pytest.mark.asyncio
+async def test_episode_lookup_by_id():
     config = podcastindex.get_config_from_env()
     index = podcastindex.init(config)
 
-    results = index.episodesByItunesId(itunesId)
+    results = await index.episodesByItunesId(itunesId)
     latest_episode_id = results["items"][0]["id"]
 
-    results = index.episodeById(latest_episode_id)
+    results = await index.episodeById(latest_episode_id)
     assert results["episode"]["id"] == latest_episode_id, "Episode fetched by ID should match ID used in query"

--- a/tests/test_podcast_lookup.py
+++ b/tests/test_podcast_lookup.py
@@ -1,6 +1,7 @@
 import logging
 
 import podcastindex
+import pytest
 
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger()
@@ -11,25 +12,28 @@ feedId = 522613
 itunesId = 201671138
 
 
-def test_podcast_lookup_by_feedurl():
+@pytest.mark.asyncio
+async def test_podcast_lookup_by_feedurl():
     config = podcastindex.get_config_from_env()
     index = podcastindex.init(config)
 
-    results = index.podcastByFeedUrl(feedUrl)
+    results = await index.podcastByFeedUrl(feedUrl)
     assert results["feed"]["title"] == podcastTitle, "Did not find the right podcast when doing lookup by URL"
 
 
-def test_podcast_lookup_by_byfeedid():
+@pytest.mark.asyncio
+async def test_podcast_lookup_by_byfeedid():
     config = podcastindex.get_config_from_env()
     index = podcastindex.init(config)
 
-    results = index.podcastByFeedId(feedId)
+    results = await index.podcastByFeedId(feedId)
     assert results["feed"]["title"] == podcastTitle, "Did not find the right podcast when doing lookup by Feed ID"
 
 
-def test_podcast_lookup_by_byitunesid():
+@pytest.mark.asyncio
+async def test_podcast_lookup_by_byitunesid():
     config = podcastindex.get_config_from_env()
     index = podcastindex.init(config)
 
-    results = index.podcastByItunesId(itunesId)
+    results = await index.podcastByItunesId(itunesId)
     assert results["feed"]["title"] == podcastTitle, "Did not find the right podcast when doing lookup by Itunes ID"

--- a/tests/test_recent_episodes.py
+++ b/tests/test_recent_episodes.py
@@ -2,6 +2,7 @@ import logging
 import time
 
 import podcastindex
+import pytest
 
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger()
@@ -41,12 +42,12 @@ def _log_results(context, results):
 #             more_recent_timestamp >= next_item_timestamp
 #         ), "Recent episodes should be returned in reverse chronological order"
 
-
-def test_recent_episodes_max():
+@pytest.mark.asyncio
+async def test_recent_episodes_max():
     config = podcastindex.get_config_from_env()
     index = podcastindex.init(config)
 
-    results = index.recentEpisodes(max=15)
+    results = await index.recentEpisodes(max=15)
     assert len(results["items"]) == 15, "By default we expect to get back 10 results"
 
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,17 +1,18 @@
 import logging
 
 import podcastindex
+import pytest
 
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger()
 
-
-def test_search_found():
+@pytest.mark.asyncio
+async def test_search_found():
     config = podcastindex.get_config_from_env()
     index = podcastindex.init(config)
 
     query_str = "This American Life"
-    results = index.search(query_str)
+    results = await index.search(query_str)
     found = False
 
     for feed in results["feeds"]:
@@ -24,12 +25,13 @@ def test_search_found():
     assert found, "Count not find podcast that should be in the feed: {}".format(query_str)
 
 
-def test_search_clean():
+@pytest.mark.asyncio
+async def test_search_clean():
     config = podcastindex.get_config_from_env()
     index = podcastindex.init(config)
 
     query_str = "Sex"
-    results_dirty = index.search(query_str, clean=False)
-    results_clean = index.search(query_str, clean=True)
+    results_dirty = await index.search(query_str, clean=False)
+    results_clean = await index.search(query_str, clean=True)
 
     assert len(results_clean["feeds"]) < len(results_dirty["feeds"])

--- a/tests/test_trending_podcasts.py
+++ b/tests/test_trending_podcasts.py
@@ -2,6 +2,7 @@ import logging
 import time
 
 import podcastindex
+import pytest
 
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger()
@@ -16,51 +17,56 @@ def _log_results(context, results):
         )
 
 
-def test_trending_podcasts_max():
+@pytest.mark.asyncio
+async def test_trending_podcasts_max():
     config = podcastindex.get_config_from_env()
     index = podcastindex.init(config)
 
-    results = index.trendingPodcasts(max=15)
+    results = await index.trendingPodcasts(max=15)
     assert len(results["feeds"]
                ) == 15, "By default we expect to get back 10 results"
 
 
-def test_trending_podcasts_since():
+@pytest.mark.asyncio
+async def test_trending_podcasts_since():
     config = podcastindex.get_config_from_env()
     index = podcastindex.init(config)
 
-    results = index.trendingPodcasts(since=-(24 * 3600))
+    results = await index.trendingPodcasts(since=-(24 * 3600))
     for feed in results["feeds"]:
         last_updated = feed["newestItemPublishTime"]
         assert time.time() - last_updated < 24 * 3600
 
 
-def test_trending_podcasts_lang():
+@pytest.mark.asyncio
+async def test_trending_podcasts_lang():
     config = podcastindex.get_config_from_env()
     index = podcastindex.init(config)
 
-    results = index.trendingPodcasts(lang=["es"])
+    results = await index.trendingPodcasts(lang=["es"])
     for feed in results["feeds"]:
         assert feed["language"] == "es"
 
 
-def test_trending_podcasts_categories():
+@pytest.mark.asyncio
+async def test_trending_podcasts_categories():
     config = podcastindex.get_config_from_env()
     index = podcastindex.init(config)
     categories = ["News", "Comedy"]
 
-    results = index.trendingPodcasts(categories=categories)
+    results = await index.trendingPodcasts(categories=categories)
     for feed in results["feeds"]:
         assert categories[0] in feed["categories"].values(
         ) or categories[1] in feed["categories"].values()
 
 
-def test_trending_podcasts_not_categories():
+@pytest.mark.asyncio
+async def test_trending_podcasts_not_categories():
     config = podcastindex.get_config_from_env()
     index = podcastindex.init(config)
     categories = ["News", "Comedy"]
 
-    results = index.trendingPodcasts(not_categories=categories)
+    results = await index.trendingPodcasts(not_categories=categories)
     for feed in results["feeds"]:
         for id in feed["categories"]:
             assert not feed["categories"][id] in categories


### PR DESCRIPTION
Made a refactor to support asynchronous api calls. Haven't tested all the endpoints, only the one I need (episodesByFeedId).

