### PR TITLE
Added support for the /episodes/random endpoint via the new PodcastIndex.randomEpisodes() method.

### DIFF
--- a/podcastindex/podcastindex.py
+++ b/podcastindex/podcastindex.py
@@ -467,12 +467,17 @@ class PodcastIndex:
         # Call Api for result
         return self._make_request_get_result_helper(url, payload)
 
-    def randomEpisodes(self, max=None, fulltext=False):
+    def randomEpisodes(self, max=None, lang=None, cat=None, notcat=None, fulltext=False):
         """
         Fetch a random batch of episodes, in no specific order.
+        See https://podcastindex-org.github.io/docs-api/#get-/episodes/random
+        for more information and examples on how to specify the arguments below.
 
         Args:
             max (int): Maximum number of episodes to return. Default: 1
+            lang (str): Language code to filter by.
+            cat (str): Specify that you ONLY want episodes with these categories in the results.
+            notcat (str): Specify categories of episodes to NOT show in the results.
             fulltext (bool): Return full text in the text fields. Default: False
 
         Raises:
@@ -489,6 +494,12 @@ class PodcastIndex:
         payload = {"pretty": 1}
         if max:
             payload["max"] = max
+        if lang:
+            payload["lang"] = lang
+        if cat:
+            payload["cat"] = cat
+        if notcat:
+            payload["notcat"] = notcat
         if fulltext:
             payload["fulltext"] = True
 

--- a/podcastindex/podcastindex.py
+++ b/podcastindex/podcastindex.py
@@ -467,6 +467,35 @@ class PodcastIndex:
         # Call Api for result
         return self._make_request_get_result_helper(url, payload)
 
+    def randomEpisodes(self, max=None, fulltext=False):
+        """
+        Fetch a random batch of episodes, in no specific order.
+
+        Args:
+            max (int): Maximum number of episodes to return. Default: 1
+            fulltext (bool): Return full text in the text fields. Default: False
+
+        Raises:
+            requests.exceptions.HTTPError: When the status code is not OK.
+            requests.exceptions.ReadTimeout: When the request times out.
+
+        Returns:
+            Dict: API response
+        """
+        # Setup request
+        url = self.base_url + "/episodes/random"
+
+        # Setup payload
+        payload = {"pretty": 1}
+        if max:
+            payload["max"] = max
+        if fulltext:
+            payload["fulltext"] = True
+
+        # Call Api for result
+        return self._make_request_get_result_helper(url, payload)
+
+
     def recentEpisodes(
         self, max=None, excluding=None, before_episode_id=None, fulltext=False
     ):

--- a/tests/test_random_episodes.py
+++ b/tests/test_random_episodes.py
@@ -1,0 +1,18 @@
+import logging
+
+import podcastindex
+
+logging.basicConfig(level=logging.DEBUG)
+logger = logging.getLogger()
+
+def test_random_episodes():
+    config = podcastindex.get_config_from_env()
+    index = podcastindex.init(config)
+
+    # Basic test
+    results = index.randomEpisodes(max=1)
+    assert len(results["episodes"]) == 1, "Expected exactly one episode."
+
+    # Test that changing the `max` parameter impacts the number of episodes returned
+    results = index.randomEpisodes(max=3)
+    assert len(results["episodes"]) == 3, "Expected exactly three episodes."


### PR DESCRIPTION
This PR adds support for the /episodes/random endpoint via the new PodcastIndex.randomEpisodes() method.

See API docs for more information on this endpoint:
https://podcastindex-org.github.io/docs-api/#get-/episodes/random